### PR TITLE
Fix all null geometries

### DIFF
--- a/R/simplify.R
+++ b/R/simplify.R
@@ -117,12 +117,7 @@ ms_simplify.geo_list <- function(input, keep = 0.05, method = NULL, keep_shapes 
                    no_repair = no_repair, snap = snap, explode = explode,
                    force_FC = force_FC, drop_null_geometries = FALSE)
 
-  ret <- geojsonio::geojson_list(ret)
-
-  # if (drop_null_geometries) {
-  #   ret <- drop_null_geometries.geo_list(ret)
-  # }
-  ret
+  geojsonio::geojson_list(ret)
 }
 
 #' @describeIn ms_simplify For SpatialPolygonsDataFrame objects
@@ -158,13 +153,6 @@ ms_simplify_sp <- function(input, keep, method, keep_shapes, no_repair, snap, ex
 
   ret <- apply_mapshaper_commands(data = geojson, command = call, force_FC = TRUE)
 
-  # If keep_shapes == FALSE, the features that are reduced to nothing are still
-  # present but the geometries are NULL. This will remove them, otherwise
-  # readOGR doesn't like it
-  # if (!keep_shapes) {
-  #   ret <- drop_null_geometries.geo_json(ret)
-  # }
-
   if (grepl('^\\{"type":"GeometryCollection"', ret)) {
     stop("Cannot convert result to a Spatial* object.
          It is likely too much simplification was applied and all features
@@ -182,9 +170,6 @@ ms_simplify_json <- function(input, keep, method, keep_shapes, no_repair, snap,
 
   ret <- apply_mapshaper_commands(data = input, command = call, force_FC = force_FC)
 
-  # if (drop_null_geometries) {
-  #   ret <- drop_null_geometries.geo_json(ret)
-  # }
   ret
 }
 

--- a/R/simplify.R
+++ b/R/simplify.R
@@ -119,9 +119,9 @@ ms_simplify.geo_list <- function(input, keep = 0.05, method = NULL, keep_shapes 
 
   ret <- geojsonio::geojson_list(ret)
 
-  if (drop_null_geometries) {
-    ret <- drop_null_geometries.geo_list(ret)
-  }
+  # if (drop_null_geometries) {
+  #   ret <- drop_null_geometries.geo_list(ret)
+  # }
   ret
 }
 

--- a/R/simplify.R
+++ b/R/simplify.R
@@ -152,7 +152,7 @@ ms_simplify_sp <- function(input, keep, method, keep_shapes, no_repair, snap, ex
 
   call <- make_simplify_call(keep = keep, method = method,
                              keep_shapes = keep_shapes, no_repair = no_repair,
-                             snap = snap, explode = explode)
+                             snap = snap, explode = explode, drop_null_geometries = !keep_shapes)
 
   geojson <- sp_to_GeoJSON(input)
 
@@ -161,8 +161,14 @@ ms_simplify_sp <- function(input, keep, method, keep_shapes, no_repair, snap, ex
   # If keep_shapes == FALSE, the features that are reduced to nothing are still
   # present but the geometries are NULL. This will remove them, otherwise
   # readOGR doesn't like it
-  if (!keep_shapes) {
-    ret <- drop_null_geometries.geo_json(ret)
+  # if (!keep_shapes) {
+  #   ret <- drop_null_geometries.geo_json(ret)
+  # }
+
+  if (grepl('^\\{"type":"GeometryCollection"', ret)) {
+    stop("Cannot convert result to a Spatial* object.
+         It is likely too much simplification was applied and all features
+         were reduced to null.", call. = FALSE)
   }
 
   GeoJSON_to_sp(ret, proj = attr(geojson, "proj4"))
@@ -172,17 +178,17 @@ ms_simplify_json <- function(input, keep, method, keep_shapes, no_repair, snap,
                              explode, force_FC, drop_null_geometries) {
   call <- make_simplify_call(keep = keep, method = method,
                              keep_shapes = keep_shapes, no_repair = no_repair,
-                             snap = snap, explode = explode)
+                             snap = snap, explode = explode, drop_null_geometries = drop_null_geometries)
 
   ret <- apply_mapshaper_commands(data = input, command = call, force_FC = force_FC)
 
-  if (drop_null_geometries) {
-    ret <- drop_null_geometries.geo_json(ret)
-  }
+  # if (drop_null_geometries) {
+  #   ret <- drop_null_geometries.geo_json(ret)
+  # }
   ret
 }
 
-make_simplify_call <- function(keep, method, keep_shapes, no_repair, snap, explode) {
+make_simplify_call <- function(keep, method, keep_shapes, no_repair, snap, explode, drop_null_geometries) {
   if (keep > 1 || keep <= 0) stop("keep must be > 0 and <= 1")
 
   if (is.null(method)) {
@@ -197,9 +203,10 @@ make_simplify_call <- function(keep, method, keep_shapes, no_repair, snap, explo
   if (snap) snap <- "snap" else snap <- NULL
   if (keep_shapes) keep_shapes <- "keep-shapes" else keep_shapes <- NULL
   if (no_repair) no_repair <- "no-repair" else no_repair <- NULL
+  if (drop_null_geometries) drop_null <- "-filter remove-empty" else drop_null <- NULL
 
   call <- list(explode, snap, "-simplify", keep, method,
-                  keep_shapes, no_repair)
+                  keep_shapes, no_repair, drop_null)
 
   call
 }

--- a/tests/testthat/test-simplify.R
+++ b/tests/testthat/test-simplify.R
@@ -405,6 +405,9 @@ multipoly <- structure('
   }
 ', class = c("json", "geo_json"))
 
+multipoly_list <- geojson_list(multipoly)
+multipoly_spdf <- geojson_sp(multipoly)
+
 test_that("ms_simplify works with drop_null_geometries", {
   out_drop <- ms_simplify(multipoly, keep_shapes = FALSE, drop_null_geometries = TRUE)
   expect_equal(out_drop, structure("{\"type\":\"FeatureCollection\",\"features\":[\n{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[-152.823293088065,-51.6391932864114],[-146.114812898716,-56.7281980257939],[-154.774197336172,-60.4935989121959],[-152.823293088065,-51.6391932864114]]]},\"properties\":{\"rmapshaperid\":0}}\n]}", class = c("json",
@@ -417,10 +420,9 @@ test_that("ms_simplify works with drop_null_geometries", {
 })
 
 test_that("ms_simplify.SpatialPolygonsDataFrame works keep_shapes = FALSE and ignores drop_null_geometries", {
-  spdf <- geojson_sp(multipoly)
-  out <- ms_simplify(spdf, keep_shapes = FALSE, drop_null_geometries = TRUE)
+  out <- ms_simplify(multipoly_spdf, keep_shapes = FALSE, drop_null_geometries = TRUE)
   expect_equal(length(out@polygons), 1)
-  out_nodrop <- ms_simplify(spdf, keep_shapes = FALSE, drop_null_geometries = FALSE)
+  out_nodrop <- ms_simplify(multipoly_spdf, keep_shapes = FALSE, drop_null_geometries = FALSE)
   expect_equal(out, out_nodrop)
 })
 
@@ -431,4 +433,18 @@ test_that("ms_simplify works with lines", {
   expect_equal(ms_simplify(line), expected_json)
   expect_equal(ms_simplify(line_list), geojson_list(expected_json))
   expect_equal(ms_simplify(line_spdf), geojson_sp(expected_json))
+})
+
+test_that("ms_simplify works correctly when all geometries are dropped", {
+  expect_error(ms_simplify(multipoly_spdf, keep = 0.001), "Cannot convert result to a Spatial\\* object")
+  expect_equal(ms_simplify(multipoly, keep = 0.001), structure("{\"type\":\"GeometryCollection\",\"geometries\":[\n\n]}", class = c("json",
+                                                                                                                                    "geo_json")))
+  expect_equal(ms_simplify(multipoly_list, keep = 0.001), structure(list(type = "FeatureCollection", features = list(structure(list(
+    type = "Feature", geometry = NULL, properties = structure(list(
+      rmapshaperid = 0L), .Names = "rmapshaperid")), .Names = c("type",
+                                                                "geometry", "properties")), structure(list(type = "Feature",
+                                                                                                           geometry = NULL, properties = structure(list(rmapshaperid = 1L), .Names = "rmapshaperid")), .Names = c("type",
+                                                                                                                                                                                                                  "geometry", "properties")), structure(list(type = "Feature",
+                                                                                                                                                                                                                                                             geometry = NULL, properties = structure(list(rmapshaperid = 2L), .Names = "rmapshaperid")), .Names = c("type",
+                                                                                                                                                                                                                                                                                                                                                                    "geometry", "properties")))), .Names = c("type", "features"), class = "geo_list", from = "json"))
 })


### PR DESCRIPTION
This simplifies the dropping of null geometries by including it in the main mapshaper call, rather than having another trip into the mapshaper V8 context.

It also errors more gracefully when the object is siimplified so much that all geometries are null. This closes #29 and closes #32.