### PR TITLE
Pass drop_null_geometries through

### DIFF
--- a/R/simplify.R
+++ b/R/simplify.R
@@ -123,7 +123,8 @@ ms_simplify.geo_list <- function(input, keep = 0.05, method = NULL, keep_shapes 
 
   ret <-  ms_simplify_json(input = geojson, keep = keep, method = method, keep_shapes = keep_shapes,
                    no_repair = no_repair, snap = snap, explode = explode,
-                   force_FC = force_FC, drop_null_geometries = FALSE, snap_interval = snap_interval)
+                   force_FC = force_FC, drop_null_geometries = drop_null_geometries,
+                   snap_interval = snap_interval)
 
   geojsonio::geojson_list(ret)
 }


### PR DESCRIPTION
Following on from https://github.com/ateucher/rmapshaper/pull/43#issuecomment-242737294 I think that `drop_null_geometries` should be passed though or at least have some information somewhere explaining that it is always `FALSE` for `geo_list`s