### PR TITLE
handle various column classes

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -173,16 +173,22 @@ check_character_input <- function(x) {
 curly_brace_na <- function(x) {
   UseMethod("curly_brace_na")
 }
-
+curly_brace_na.data.frame <- function(x) {
+  chr_or_factor <- unlist(lapply(x, class)) %in% c("character", "factor")
+  if (any(chr_or_factor)) {
+    x[, chr_or_factor][x[, chr_or_factor] == "{ }"] <- NA
+  }
+  x
+}
 curly_brace_na.Spatial <- function(x) {
-  x@data[x@data == "{ }"] <- NA
+  x@data <- curly_brace_na(x@data)
   x
 }
 
 curly_brace_na.sf <- function(x) {
   sf_col <- which(names(x) == attr(x, "sf_column"))
   x <- as.data.frame(x)
-  x[,-sf_col][x[,-sf_col] == "{ }"] <- NA
+  x[,-sf_col] <- curly_brace_na(x[,-sf_col, drop = FALSE])
   sf::st_as_sf(x)
 }
 

--- a/tests/testthat/test-simplify.R
+++ b/tests/testthat/test-simplify.R
@@ -476,7 +476,6 @@ test_that("ms_simplify works with very small values of 'keep", {
 
 
 # SF ----------------------------------------------------------------------
-
 if (has_sf) {
   test_that("ms_simplify works with sf", {
     multipoly_sf <- st_as_sf(multipoly_spdf)
@@ -486,10 +485,38 @@ if (has_sf) {
   })
 
 
+
   test_that("ms_simplify works with sfc", {
     poly_sfc <- st_as_sfc(poly_sp)
     line_sfc <- st_as_sfc(line_sp)
     expect_is(ms_simplify(poly_sfc), c("sfc_POLYGON", "sfc"))
     expect_is(ms_simplify(line_sfc), c("sfc_LINESTRING", "sfc"))
+  })
+
+  xs <- st_polygon(list(cbind(approx(c(0, 0, 1, 1, 0))$y,
+                               approx(c(0, 1, 1, 0, 0))$y)))
+
+  test_that("ms_simplify works with various column types", {
+    xsf <- st_sf(geometry = st_sfc(xs, xs + 2, xs + 3), a = 1:3)
+    nr <- dim(xsf)[1]
+    various_types <- list(
+      date = Sys.Date() + seq_len(nr),
+      time = Sys.time() + seq_len(nr),
+      cpx = complex(nr),
+#      rw = raw(nr),
+      lst = replicate(nr, "a", simplify = FALSE)
+    )
+    for (itype in seq_along(various_types)) {
+      xsf$check_me <- various_types[[itype]]
+      context(typeof(various_types[[itype]]))
+      simp_xsf <- ms_simplify(xsf)
+      expect_is(simp_xsf, c("sf", "data.frame"))
+      ## not currently working for POSIXct
+      #expect_identical(simp_xsf$check_me, various_types[[itype]])
+    }
+
+    ## raw special case
+    xsf$check_me <- raw(nr)
+    expect_warning(simp_xsf <- ms_simplify(xsf), "NAs introduced by coercion")
   })
 }


### PR DESCRIPTION
This PR adds a slightly safer way of comparing column values to "{ }" and adds a `curly_brace_na.data.frame` method that *only compares character and factor columns*. 

The primary motivation was to enable round-tripping with Date and POSIXct columns, which error currently (5a293b051039b1006f743e02005a9db52ef2f805): 

```{r}
library(sf)
example(st_read)
x <- st_sf(date = Sys.Date() + seq_len(2), geometry = st_geometry(nc)[1:2])
rmapshaper::ms_simplify(x)
# Error in charToDate(x) : 
 # character string is not in a standard unambiguous format

y <- st_sf(date = Sys.time() + seq_len(2), geometry = st_geometry(nc)[1:2])
rmapshaper::ms_simplify(y)
#Error in as.POSIXlt.character(x, tz, ...) : 
# character string is not in a standard unambiguous format 
```

I had to remove the Date metadata here in order to run `ms_simplify`, as a real world example: 

https://github.com/mdsumner/ozplot/blame/master/README.Rmd#L100


 I kind of remember discussing this at some point, so apologies if I've missed something!  I think there will be other details and perhaps problematic and column types, but I feel like this is a reasonable PR without being comprehensive yet. :)

There's a further problem in that date-time types don't always(?) round-trip completely, and I assume that's a time zone thing - but it wouldn't have been noticed. I'll wait until this is accepted before pursuing those details, for now I've left out the round-trip test, commented out here: 

https://github.com/ateucher/rmapshaper/pull/68/files#diff-792448277e53b51a3b944f1b1873e7f8R515


