### PR TITLE
sf tiny fix

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -194,7 +194,7 @@ ms_sf <- function(input, fields_to_retain = NULL, call, sys = FALSE) {
     ret <- merge(orig_data, ret, by = ms_join_id(), all.y = TRUE,
                  sort = FALSE)
     names(ret)[names(ret) == attr(ret, "sf_column")] <- geom_name
-    sf::st_geometry(ret) <- geom_name
+    ret <- sf::st_as_sf(ret, sf_column_name = geom_name)
     ret <- ret[, setdiff(names(ret), ms_join_id())]
   }
 

--- a/tests/testthat/test-simplify.R
+++ b/tests/testthat/test-simplify.R
@@ -288,7 +288,11 @@ test_that("ms_simplify works with various column types", {
     date = Sys.Date() + seq_len(nr),
     time = Sys.time() + seq_len(nr),
     cpx = complex(nr),
-    #      rw = raw(nr),
+    unts = structure(seq_len(nr),
+                     units = structure(list(numerator = c("km", "km"), denominator = character(0)),
+                                       class = "symbolic_units"),
+                     class = "units"),
+    # rw = raw(nr),
     lst = replicate(nr, "a", simplify = FALSE)
   )
   for (itype in seq_along(various_types)) {
@@ -297,7 +301,7 @@ test_that("ms_simplify works with various column types", {
     simp_xsf <- ms_simplify(xsf)
     expect_is(simp_xsf, c("sf", "data.frame"))
     ## not currently working for POSIXct
-    #expect_identical(simp_xsf$check_me, various_types[[itype]])
+    expect_identical(simp_xsf$check_me, various_types[[itype]])
   }
 
   ## raw special case


### PR DESCRIPTION
Now attribute classes are preserved:
``` r
# recent version
library(rmapshaper)
library(spData)
library(sf)
#> Linking to GEOS 3.6.1, GDAL 2.2.4, proj.4 4.9.3

us_states2163 = st_transform(us_states, 2163)
us_states_simp2 = rmapshaper::ms_simplify(us_states2163, keep = 0.01, keep_shapes = TRUE, sys = TRUE)
plot(st_geometry(us_states2163))
```

![](https://i.imgur.com/8Oe3I6Z.png)

``` r
plot(st_geometry(us_states_simp2))
```

![](https://i.imgur.com/4AYUzbM.png)

``` r

head(us_states2163)
#> Simple feature collection with 6 features and 6 fields
#> geometry type:  MULTIPOLYGON
#> dimension:      XY
#> bbox:           xmin: -1389101 ymin: -2069059 xmax: 2295443 ymax: 67481.2
#> epsg (SRID):    2163
#> proj4string:    +proj=laea +lat_0=45 +lon_0=-100 +x_0=0 +y_0=0 +a=6370997 +b=6370997 +units=m +no_defs
#>   GEOID        NAME   REGION           AREA total_pop_10 total_pop_15
#> 1    01     Alabama    South 133709.27 km^2      4712651      4830620
#> 2    04     Arizona     West 295281.25 km^2      6246816      6641928
#> 3    08    Colorado     West 269573.06 km^2      4887061      5278906
#> 4    09 Connecticut Norteast  12976.59 km^2      3545837      3593222
#> 5    12     Florida    South 151052.01 km^2     18511620     19645772
#> 6    13     Georgia    South 152725.21 km^2      9468815     10006693
#>                         geometry
#> 1 MULTIPOLYGON (((1074678 -10...
#> 2 MULTIPOLYGON (((-1376627 -1...
#> 3 MULTIPOLYGON (((-758041.6 -...
#> 4 MULTIPOLYGON (((2142347 242...
#> 5 MULTIPOLYGON (((1853170 -20...
#> 6 MULTIPOLYGON (((1308636 -10...
head(us_states_simp2)
#> Simple feature collection with 6 features and 7 fields
#> geometry type:  POLYGON
#> dimension:      XY
#> bbox:           xmin: -1376627 ymin: -1993727 xmax: 2294102 ymax: 65870.01
#> epsg (SRID):    2163
#> proj4string:    +proj=laea +lat_0=45 +lon_0=-100 +x_0=0 +y_0=0 +a=6370997 +b=6370997 +units=m +no_defs
#>   GEOID        NAME   REGION           AREA total_pop_10 total_pop_15
#> 1    01     Alabama    South 133709.27 km^2      4712651      4830620
#> 2    04     Arizona     West 295281.25 km^2      6246816      6641928
#> 3    08    Colorado     West 269573.06 km^2      4887061      5278906
#> 4    09 Connecticut Norteast  12976.59 km^2      3545837      3593222
#> 5    12     Florida    South 151052.01 km^2     18511620     19645772
#> 6    13     Georgia    South 152725.21 km^2      9468815     10006693
#>   rmapshaperid                       geometry
#> 1            0 POLYGON ((1074678 -1035935,...
#> 2            1 POLYGON ((-1376627 -1244047...
#> 3            2 POLYGON ((-758041.6 -402936...
#> 4            3 POLYGON ((2142347 24224.67,...
#> 5            4 POLYGON ((1431304 -1427762,...
#> 6            5 POLYGON ((1308636 -1000511,...
```

Few comments/questions:
1. There are several tests failures (I think unrelated to this change).
2. The output has a new `rmapshaperid`
3. I can write some "units" tests, however, I've seen that you are using geojsons as testing objects. Should I use some simple sf object and the output of `dput()` there?

Created on 2018-09-06 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).