### PR TITLE
maintain tbl_df input

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -202,7 +202,10 @@ ms_sf <- function(input, call, sys = FALSE) {
     names(ret)[names(ret) == attr(ret, "sf_column")] <- geom_name
     sf::st_geometry(ret) <- geom_name
   }
-
+  ##maintain tbl_df
+  if (all(class(input) == c("sf", "tbl_df", "tbl", "data.frame"))) {
+    class(ret) <- c("sf", "tbl_df", "tbl", "data.frame")
+  }
   ret
 }
 


### PR DESCRIPTION
small change to ensure tibble-in, tibble-out

``` r
  f <- system.file("gpkg/nc.gpkg", package = "sf", mustWork = TRUE)

x <- sf::read_sf(f)
o <- rmapshaper::ms_simplify(x)
class(x)
#> [1] "sf"         "tbl_df"     "tbl"        "data.frame"
class(o)
#> [1] "sf"         "tbl_df"     "tbl"        "data.frame"
```

<sup>Created on 2019-11-06 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>


I'm motivated by this because I rely on the behaviour of tibble in several places, I don't think it can cause problems - the test for *it's a tibble* is very specific (could be made more general in future if needed). 

The only difference is the class attribute, as in if you compare  `sf::st_as_sf(tibble::as_tibble(rmapshapher::ms_simplify(x)))` with current behaviour, you get an identical object with this PR. 

