### PR TITLE
Added sys_mem to the sys=TRUE example

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Then you can use the `sys` argument in any rmapshaper function:
 
 ``` r
 states_simp_internal <- ms_simplify(states_sf)
-states_simp_sys <- ms_simplify(states_sf, sys = TRUE)
+states_simp_sys <- ms_simplify(states_sf, sys = TRUE, sys_mem=8) #sys_mem specifies the amout of memory to use in Gb.  It defaults to 8 if omitted. 
 
 all.equal(states_simp_internal, states_simp_sys)
 #>  [1] "Component \"geometry\": Component 1: Component 1: Mean relative difference: 0.03139317"  


### PR DESCRIPTION
I spent so long waiting for the 'Allocating 8 GB of heap memory'.  Then I discovered that I could have thrown 20 GB to is right away.  My runs were much faster!! I would like to spare others this pain, and promote the sys_mem parameter to the example.