### PR TITLE
Adding sys_mem to the example line.

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -169,7 +169,7 @@ Then you can use the `sys` argument in any rmapshaper function:
 
 ```{r eval=nzchar(Sys.which("mapshaper"))}
 states_simp_internal <- ms_simplify(states_sf)
-states_simp_sys <- ms_simplify(states_sf, sys = TRUE)
+states_simp_sys <- ms_simplify(states_sf, sys = TRUE, sys_mem=8) #sys_mem specifies the amout of memory to use in Gb.  It defaults to 8 if omitted. 
 
 all.equal(states_simp_internal, states_simp_sys)
 ```


### PR DESCRIPTION
I spent so long waiting for the 'Allocating 8 GB of heap memory'. Then I discovered that I could have thrown 20 GB to is right away. My runs were much faster!! I would like to spare others this pain, and promote the sys_mem parameter to the example.